### PR TITLE
update_golang_version: {stable:"1.15.2"} - try #2

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -71,7 +71,7 @@ jobs:
           make checksum
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install kubectl
         shell: bash

--- a/.github/workflows/kic_image.yml
+++ b/.github/workflows/kic_image.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Download Dependencies
         run: go mod download

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install libvirt
         run: |
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install libvirt
         run: |
@@ -114,7 +114,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -197,7 +197,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -340,7 +340,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -476,7 +476,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -582,7 +582,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -677,7 +677,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -757,7 +757,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -867,7 +867,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -949,7 +949,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -1053,7 +1053,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -1133,7 +1133,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Download Dependencies
         run: go mod download
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install libvirt
         run: |
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install libvirt
         run: |
@@ -112,7 +112,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -195,7 +195,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -338,7 +338,7 @@ jobs:
           echo "------------------------"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -474,7 +474,7 @@ jobs:
           Get-WmiObject -class Win32_ComputerSystem
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install tools
         continue-on-error: true
@@ -580,7 +580,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -675,7 +675,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -755,7 +755,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -865,7 +865,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -947,7 +947,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -1051,7 +1051,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 
@@ -1131,7 +1131,7 @@ jobs:
       # go 1.14.6+ is needed because of this bug https://github.com/golang/go/issues/39308
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.6'
+          go-version: '1.15.2'
           stable: true
       - name: Install gopogh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 os: linux
 language: go
 go:
-  - 1.14.6
+  - 1.15.2
 env:
   global:
     - GOPROXY=https://proxy.golang.org
@@ -11,7 +11,7 @@ matrix:
   include:
     - language: go
       name: Code Lint
-      go: 1.14.6
+      go: 1.15.2
       env:
         - TESTSUITE=lintall
       before_install:
@@ -20,7 +20,7 @@ matrix:
 
     - language: go
       name: Unit Test
-      go: 1.14.6
+      go: 1.15.2
       env:
         - TESTSUITE=unittest
       before_install:
@@ -29,7 +29,7 @@ matrix:
 
     - language: go
       name: Build
-      go: 1.14.6
+      go: 1.15.2
       script: make
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DEB_VERSION ?= $(subst -,~,$(RAW_VERSION))
 RPM_VERSION ?= $(DEB_VERSION)
 
 # used by hack/jenkins/release_build_and_upload.sh and KVM_BUILD_IMAGE, see also BUILD_IMAGE below
-GO_VERSION ?= 1.14.6
+GO_VERSION ?= 1.15.2
 
 INSTALL_SIZE ?= $(shell du out/minikube-windows-amd64.exe | cut -f1)
 BUILDROOT_BRANCH ?= 2019.02.11

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/minikube
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go/storage v1.8.0

--- a/hack/jenkins/common.sh
+++ b/hack/jenkins/common.sh
@@ -31,7 +31,7 @@ export KUBECONFIG="${TEST_HOME}/kubeconfig"
 export PATH=$PATH:"/usr/local/bin/:/usr/local/go/bin/:$GOPATH/bin"
 
 # installing golang so we could do go get for gopogh
-sudo ./installers/check_install_golang.sh "1.14.6" "/usr/local" || true
+sudo ./installers/check_install_golang.sh "1.15.2" "/usr/local" || true
 
 docker rm -f -v $(docker ps -aq) >/dev/null 2>&1 || true
 docker volume prune -f || true


### PR DESCRIPTION
fixes #4392

Automatically created PR to update repo according to the Plan:

```
{
  ".github/workflows/iso.yml": {
    "replace": {
      "go-version: '.*": "go-version: '1.15.2'"
    }
  },
  ".github/workflows/kic_image.yml": {
    "replace": {
      "go-version: '.*": "go-version: '1.15.2'"
    }
  },
  ".github/workflows/master.yml": {
    "replace": {
      "go-version: '.*": "go-version: '1.15.2'"
    }
  },
  ".github/workflows/pr.yml": {
    "replace": {
      "go-version: '.*": "go-version: '1.15.2'"
    }
  },
  ".travis.yml": {
    "replace": {
      "go: .*": "go: 1.15.2",
      "go:\\n  - .*": "go:\n  - 1.15.2"
    }
  },
  "Makefile": {
    "replace": {
      "GO_VERSION \\?= .*": "GO_VERSION ?= 1.15.2"
    }
  },
  "go.mod": {
    "replace": {
      "(?m)^go .*": "go 1.15"
    }
  },
  "hack/jenkins/common.sh": {
    "replace": {
      "sudo \\.\\/installers\\/check_install_golang\\.sh \\\".*\\\" \\\"\\/usr\\/local\\\"": "sudo ./installers/check_install_golang.sh \"1.15.2\" \"/usr/local\""
    }
  }
}
```