### PR TITLE
update-kicbase-version: {"v0.0.13"}

### DIFF
--- a/pkg/drivers/kic/types.go
+++ b/pkg/drivers/kic/types.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Version is the current version of kic
-	Version = "v0.0.13-snapshot1"
+	Version = "v0.0.13"
 	// SHA of the kic base image
 	baseImageSHA = "4d43acbd0050148d4bc399931f1b15253b5e73815b63a67b8ab4a5c9e523403f"
 )


### PR DESCRIPTION
fixes #9420

Automatically created PR to update repo according to the Plan:

```
{
  "pkg/drivers/kic/types.go": {
    "replace": {
      "Version = \".*\"": "Version = \"v0.0.13\""
    }
  }
}
```